### PR TITLE
Fix old migrations; caused problems with deinstall

### DIFF
--- a/migrations/01_init_plugin.php
+++ b/migrations/01_init_plugin.php
@@ -9,7 +9,11 @@ class InitPlugin extends Migration
             `activated` tinyint(4) NOT NULL DEFAULT '0',
             `publishing_allowed` tinyint(4) NOT NULL DEFAULT '0',
             PRIMARY KEY (`Seminar_id`, `evasys_id`)
-        ) ENGINE=MyISAM
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
         ");
 	}
+
+    function down() {
+        // do we want to remove this table on deinstallation?
+    }
 }

--- a/migrations/02_init_settings.php
+++ b/migrations/02_init_settings.php
@@ -45,4 +45,13 @@ class InitSettings extends Migration
             'description' => "Should students see the results of an evaluation?"
         ));
 	}
+
+    function down() {
+        Config::get()->delete("EVASYS_WSDL");
+        Config::get()->delete("EVASYS_URI");
+        Config::get()->delete("EVASYS_USER");
+        Config::get()->delete("EVASYS_PASSWORD");
+        Config::get()->delete("EVASYS_CACHE");
+        Config::get()->delete("EVASYS_PUBLISH_RESULTS");
+    }
 }

--- a/migrations/03_multiple_evaluations_per_course.php
+++ b/migrations/03_multiple_evaluations_per_course.php
@@ -1,6 +1,7 @@
 <?php
 class MultipleEvaluationsPerCourse extends Migration
 {
+    // not needed anymore
     function up(){
         DBManager::get()->exec("
             ALTER TABLE evasys_seminar DROP PRIMARY KEY;

--- a/migrations/06_add_to_semclasses.php
+++ b/migrations/06_add_to_semclasses.php
@@ -12,4 +12,14 @@ class AddToSemclasses extends Migration
             $sem_class->store();
         }
 	}
+
+    function down() {
+        // is there a better way?
+        foreach ($GLOBALS['SEM_CLASS'] as $sem_class) {
+		    $modules = $sem_class['modules'];
+            unset($modules['EvasysPlugin']);
+            $sem_class->setModules($modules);
+            $sem_class->store();
+        }
+    }
 }

--- a/migrations/07_add_export_dozent_by_email.php
+++ b/migrations/07_add_export_dozent_by_email.php
@@ -10,4 +10,8 @@ class AddExportDozentByEmail extends Migration
             'description' => "Which field should be used to export the dozent (user_id, email, datafield_id)."
         ));
 	}
+
+    function down() {
+        Config::get()->delete("EVASYS_EXPORT_DOZENT_BY_FIELD");
+    }
 }

--- a/migrations/09_add_course_profiles.php
+++ b/migrations/09_add_course_profiles.php
@@ -233,6 +233,11 @@ class AddCourseProfiles extends Migration
             DROP COLUMN `publishing_allowed_by_dozent`
         ");
 
+        // revert up migration (line 209-215), which will fail on reinstall, since evasys_seminar is not dropped on deinstallation
+        // with error: dublicate key 'evasys_id'
+        DBManager::get()->exec("ALTER TABLE `evasys_seminar` DROP PRIMARY KEY, DROP KEY `evasys_id`");
+        DBManager::get()->exec("ALTER TABLE `evasys_seminar` ADD PRIMARY KEY ( `Seminar_id` , `evasys_id` )");
+
         Config::get()->delete("EVASYS_TRANSFER_PERMISSION");
 
         DBManager::get()->exec("

--- a/migrations/14_setup_upload_cronjob.php
+++ b/migrations/14_setup_upload_cronjob.php
@@ -44,4 +44,10 @@ class SetupUploadCronjob extends Migration {
             ':hour'        => $new_job['hour']
         ));
     }
+
+    //todo
+    function down()
+    {
+        // remove cronjob
+    }
 }


### PR DESCRIPTION
Some migrations had to be fixed in order to cleanly deinstall
the plugin. Now, the plugin can be deinstalled and installed again,
without errors.

TODO: remove evasys-cronjob on deinstallation