### PR TITLE
Fallback for individual eva-course-identifier

### DIFF
--- a/lib/EvasysSeminar.php
+++ b/lib/EvasysSeminar.php
@@ -244,11 +244,11 @@ class EvasysSeminar extends SimpleORMap
                 $id = $this['Seminar_id'];
                 break;
             case "number":
-                $id = $this['VeranstaltungsNummer'];
+                $id = empty($this['VeranstaltungsNummer']) ? $this['Seminar_id'] : $this['VeranstaltungsNummer'];
                 break;
             default: //Datenfeld:
                 $datafield_entry = DatafieldEntryModel::findByModel($this->course, Config::get()->EVASYS_COURSE_IDENTIFIER);
-                $id = $datafield_entry[0]['content'];
+                $id = empty($datafield_entry[0]['content']) ? $this['Seminar_id'] : $datafield_entry[0]['content'];
                 break;
         }
         return $id;


### PR DESCRIPTION
If EVASYS_COURSE_IDENTIFIER is set in Studip config,
it may be set to a field which is empty in certain seminars.
In this case the internal studip seminar_id should be
used as fallback. Otherwise the transfer to evasys would
fail since the unique identifier for the seminar is empty.